### PR TITLE
Draft: Add UDS support documentation for Apache reverse proxy #6890

### DIFF
--- a/content/doc/book/system-administration/reverse-proxy-configuration-with-jenkins/reverse-proxy-configuration-apache.adoc
+++ b/content/doc/book/system-administration/reverse-proxy-configuration-with-jenkins/reverse-proxy-configuration-apache.adoc
@@ -31,6 +31,7 @@ Choose the technique that best meets your needs:
 * <<mod_proxy>>
 * <<mod_proxy with HTTPS>>
 * <<mod_rewrite>>
+* <<mod_proxy_unix_sockets>>
 
 This 6 minute tutorial from Darin Pope configures Apache httpd on Alma Linux as a reverse proxy with <<mod_proxy>>.
 
@@ -316,6 +317,129 @@ Jenkins can't run on \http://example.com:8081/ci and be reverse proxied at \http
 The _ProxyRequests Off_ prevents Apache from functioning as a forward
 proxy server (except for _ProxyPass_), it is advised to include it
 unless the server should function as a proxy.
+
+== mod_proxy_unix_sockets
+
+Apache can be configured to proxy requests to Jenkins over a Unix domain socket instead of a TCP port. This approach enhances security by eliminating network exposure of Jenkins and is particularly useful when Jenkins and Apache run on the same host.
+NOTE: This configuration is specific to Debian-based systems (e.g., Ubuntu). Adjustments may be required for other distributions like RHEL. Apache 2.4.7 or later is required for Unix domain socket support.
+The following Apache modules must be installed:
+
+----
+a2enmod proxy
+a2enmod proxy_http
+----
+
+[source]
+----
+sudo ufw allow http
+sudo ufw allow https
+sudo ufw reload
+sudo ufw status
+----
+
+. *Modify Jenkins to Use Unix Domain Socket* +
+Edit the Jenkins systemd service to disable TCP and enable a Unix socket:
++
+[source]
+----
+sudo systemctl edit jenkins
+----
+Add the following override:
++
+[source]
+----
+[Service]
+# Remove the previous ExecStart
+ExecStart=
+# Set the new ExecStart with Unix socket
+ExecStart=/usr/bin/jenkins --pluginroot=/var/cache/jenkins/plugins --httpPort=-1 --httpUnixDomainPath=/var/run/jenkins/jenkins.socket
+----
+Reload and restart Jenkins:
++
+[source]
+----
+sudo systemctl daemon-reload
+sudo systemctl restart jenkins
+----
+Verify the socket exists:
++
+[source]
+----
+ls -l /var/run/jenkins/jenkins.socket
+----
+
+. *Set Permissions for the Socket* +
+Ensure Apache can access the socket:
++
+[source]
+----
+sudo chown jenkins:jenkins /var/run/jenkins/jenkins.socket
+sudo chmod 660 /var/run/jenkins/jenkins.socket
+----
+NOTE: Adjust ownership if Apache runs as a different user (e.g., `www-data`).
+
+. *Configure Apache Reverse Proxy* +
+Create a new virtual host:
++
+[source]
+----
+sudo nano /etc/apache2/sites-available/jenkins.conf
+----
+Add the following:
++
+[source]
+----
+<VirtualHost *:80>
+    ServerName localhost
+
+    # Proxy to Unix domain socket
+    ProxyPass / unix:/var/run/jenkins/jenkins.socket|http://localhost/
+    ProxyPassReverse / unix:/var/run/jenkins/jenkins.socket|http://localhost/
+
+    # Preserve host header
+    ProxyPreserveHost On
+
+    # Logging
+    ErrorLog ${APACHE_LOG_DIR}/jenkins_error.log
+    CustomLog ${APACHE_LOG_DIR}/jenkins_access.log combined
+</VirtualHost>
+----
+Enable the site and restart Apache:
++
+[source]
+----
+sudo a2ensite jenkins.conf
+sudo systemctl restart apache2
+----
+
+. *Adjust Apache User/Group (Optional)* +
+If Apache needs to share socket access with Jenkins, update its user/group:
++
+[source]
+----
+sudo nano /etc/apache2/envvars
+----
+Modify:
++
+[source]
+----
+export APACHE_RUN_USER=jenkins
+export APACHE_RUN_GROUP=jenkins
+----
+Restart Apache:
++
+[source]
+----
+sudo systemctl restart apache2
+----
+
+Test the setup by accessing `http://localhost/` in a browser. Check logs if issues arise:
+[source]
+----
+sudo tail -f /var/log/apache2/jenkins_error.log
+sudo tail -f /var/log/apache2/jenkins_access.log
+----
+
 
 include::doc/book/system-administration/reverse-proxy-configuration-with-jenkins/_context_path.adoc[]
 

--- a/content/doc/book/system-administration/reverse-proxy-configuration-with-jenkins/reverse-proxy-configuration-apache.adoc
+++ b/content/doc/book/system-administration/reverse-proxy-configuration-with-jenkins/reverse-proxy-configuration-apache.adoc
@@ -320,75 +320,58 @@ unless the server should function as a proxy.
 
 == mod_proxy_unix_sockets
 
-Apache can be configured to proxy requests to Jenkins over a Unix domain socket instead of a TCP port. This approach enhances security by eliminating network exposure of Jenkins and is particularly useful when Jenkins and Apache run on the same host.
-NOTE: This configuration is specific to Debian-based systems (e.g., Ubuntu). Adjustments may be required for other distributions like RHEL. Apache 2.4.7 or later is required for Unix domain socket support.
-The following Apache modules must be installed:
+Apache can be configured to proxy requests to Jenkins over a Unix domain socket instead of a TCP port. 
+This approach enhances security by eliminating network exposure of Jenkins and is particularly useful 
+when Jenkins and Apache run on the same host.
 
+To avoid repetitive use of `sudo` in the commands below, you can switch to a root shell first by running:
+
+[source,bash]
 ----
+sudo -i
+----
+
+=== Debian-Based Systems
+
+[source,bash]
+----
+# Enable the modules using `a2enmod`
 a2enmod proxy
 a2enmod proxy_http
-----
 
-[source]
-----
-sudo ufw allow http
-sudo ufw allow https
-sudo ufw reload
-sudo ufw status
-----
+# Restart Apache to apply changes
+systemctl restart httpd
 
-. *Modify Jenkins to Use Unix Domain Socket* +
-Edit the Jenkins systemd service to disable TCP and enable a Unix socket:
-+
-[source]
-----
-sudo systemctl edit jenkins
-----
-Add the following override:
-+
-[source]
-----
+# Allow HTTP and HTTPS traffic through the firewall
+ufw allow http
+ufw allow https
+ufw reload
+ufw status
+
+# Edit the Jenkins systemd service to disable TCP and enable a Unix socket
+systemctl edit jenkins
+
+# Add the following override
 [Service]
-# Remove the previous ExecStart
 ExecStart=
 # Set the new ExecStart with Unix socket
 ExecStart=/usr/bin/jenkins --pluginroot=/var/cache/jenkins/plugins --httpPort=-1 --httpUnixDomainPath=/var/run/jenkins/jenkins.socket
-----
-Reload and restart Jenkins:
-+
-[source]
-----
-sudo systemctl daemon-reload
-sudo systemctl restart jenkins
-----
-Verify the socket exists:
-+
-[source]
-----
+
+# Reload and restart Jenkins
+systemctl daemon-reload
+systemctl restart jenkins
+
+# Verify the socket exists
 ls -l /var/run/jenkins/jenkins.socket
-----
 
-. *Set Permissions for the Socket* +
-Ensure Apache can access the socket:
-+
-[source]
-----
+# Ensure Apache can access the socket
 sudo chown jenkins:jenkins /var/run/jenkins/jenkins.socket
-sudo chmod 660 /var/run/jenkins/jenkins.socket
-----
-NOTE: Adjust ownership if Apache runs as a different user (e.g., `www-data`).
+sudo chmod 700 /var/run/jenkins/jenkins.socket
 
-. *Configure Apache Reverse Proxy* +
-Create a new virtual host:
-+
-[source]
-----
-sudo nano /etc/apache2/sites-available/jenkins.conf
-----
-Add the following:
-+
-[source]
-----
+# Create a new virtual host to proxy requests to the Unix socket
+nano /etc/apache2/sites-available/jenkins.conf
+
+# Add the following
 <VirtualHost *:80>
     ServerName localhost
 
@@ -403,43 +386,94 @@ Add the following:
     ErrorLog ${APACHE_LOG_DIR}/jenkins_error.log
     CustomLog ${APACHE_LOG_DIR}/jenkins_access.log combined
 </VirtualHost>
-----
-Enable the site and restart Apache:
-+
-[source]
-----
-sudo a2ensite jenkins.conf
-sudo systemctl restart apache2
-----
 
-. *Adjust Apache User/Group (Optional)* +
-If Apache needs to share socket access with Jenkins, update its user/group:
-+
-[source]
-----
-sudo nano /etc/apache2/envvars
-----
-Modify:
-+
-[source]
-----
+# Enable the site and restart Apache
+a2ensite jenkins.conf
+systemctl restart apache2
+
+# If Apache needs to share socket access with Jenkins, update its user/group
+nano /etc/apache2/envvars
+# Modify:
 export APACHE_RUN_USER=jenkins
 export APACHE_RUN_GROUP=jenkins
-----
-Restart Apache:
-+
-[source]
-----
-sudo systemctl restart apache2
+
+# Restart Apache
+systemctl restart apache2
+
 ----
 
-Test the setup by accessing `http://localhost/` in a browser. Check logs if issues arise:
-[source]
+=== RHEL-Based Systems
+
+This 16 minute tutorial from Darin Pope configures  Unix Domain Sockets With Apache HTTP Server and Jenkins on AlmaLinux
+
+.Configure Using Unix Domain Sockets With Apache HTTP Server and Jenkins
+video::KxFJh4184vk[youtube, width=640, height=360]
+
+
+[source,bash]
 ----
-sudo tail -f /var/log/apache2/jenkins_error.log
-sudo tail -f /var/log/apache2/jenkins_access.log
+# Ensure the modules are loaded by editing the module configuration
+dnf install httpd -y  # Install Apache if not already present
+
+# Allow HTTP and HTTPS traffic through the firewall
+firewall-cmd --zone=public --add-service=http --permanent
+firewall-cmd --zone=public --add-service=https --permanent
+firewall-cmd --reload
+
+# Edit the Jenkins systemd service to disable TCP and enable a Unix socket
+systemctl edit jenkins
+
+# Add the following override
+[Service]
+ExecStart=/usr/lib/jenkins/jenkins --pluginroot=/var/cache/jenkins/plugins --httpPort=-1 --httpUnixDomainPath=/var/run/jenkins/jenkins.socket
+
+
+# Reload and restart Jenkins
+systemctl daemon-reload
+systemctl restart jenkins
+
+# Verify the socket exists
+ls -l /var/run/jenkins/jenkins.socket
+
+# Ensure Apache can access the socket
+sudo chown jenkins:jenkins /var/run/jenkins
+sudo chmod 700 /var/run/jenkins
+systemctl restart jenkins
+
+# Create a new virtual host to proxy requests to the Unix socket
+mv welcome.conf welcome.old
+vi /etc/httpd/conf.d/jenkins.conf
+
+# Add the following
+User jenkins
+Group jenkins
+ProxyPass / unix:/var/run/jenkins/jenkins.socket|http://localhost/ nocanon
+ProxyPassReverse / unix:/var/run/jenkins/jenkins.socket|http://localhost/
+
+
+# To allow SE linux to traffic allow to the socket
+chcon -t httpd_sys_rw_content_t /var/run/jenkins/jenkins.socket
+
+
+# Restart Apache
+systemctl restart apache2
+
 ----
 
+Access `http://localhost/` in a browser. If issues arise, check the logs:
+
+To check for any error logs:
+[source,bash]
+----
+tail -f /var/log/apache2/jenkins_error.log  #Debian
+tail -f /var/log/apache2/jenkins_access.log #Debian
+----
+
+[source,bash]
+----
+tail -f /var/log/httpd/jenkins_error.log  #RHEL
+tail -f /var/log/httpd/jenkins_access.log #RHEL
+----
 
 include::doc/book/system-administration/reverse-proxy-configuration-with-jenkins/_context_path.adoc[]
 


### PR DESCRIPTION
This PR addresses issue #6890 by adding documentation for configuring Apache reverse proxy with Unix Domain Sockets (UDS) on Debian and RHEL-based systems. Changes include updated setup instructions and examples for UDS configuration. This is a draft PR—please review and suggest any improvements.